### PR TITLE
docs: fix typos and improve clarity in resources and roadmap

### DIFF
--- a/docs/resources/cybersecurity/cybsec.md
+++ b/docs/resources/cybersecurity/cybsec.md
@@ -55,7 +55,7 @@
 - [Stanford Online](https://online.stanford.edu) - Stanford University's online courses
 - [Cybrary](https://www.cybrary.it) - Cybersecurity-focused training
 - [SANS](https://www.sans.org) - Professional cybersecurity training
-- [W3Schools](https://www.w3schools.co) - Web development tutorials
+- [W3Schools](https://www.w3schools.com) - Web development tutorials
 
 ### Practice Platforms
 - [TryHackMe](https://tryhackme.com) - Guided cybersecurity challenges

--- a/docs/resources/linux/linux-networking-tools.md
+++ b/docs/resources/linux/linux-networking-tools.md
@@ -3,7 +3,7 @@
 This comprehensive cheatsheet covers a wide range of Linux networking tools, providing a one-stop reference for Linux users.
 
 ## `ping`
-The `ping` command is used to check if a remote computer is connected and making HTTP requests. It sends ICMP echo request packets to the target host and waits for a response.
+The `ping` command is used to check if a remote computer is reachable on a network. It sends ICMP echo request packets to the target host and waits for a response.
 
 **Usage Examples:**
 - `ping <hostname>`: Sends ICMP echo requests to the specified hostname.
@@ -423,17 +423,17 @@ The `python -m SimpleHTTPServer` command can be used to quickly serve files from
 * `python -m SimpleHTTPServer --help`: Displays the available options for the SimpleHTTPServer module.
 
 
-## ipealc
+## ipcalc
 
-`ipealc` is a command-line tool used to calculate IP addresses and subnet information.
+`ipcalc` is a command-line tool used to calculate IP addresses and subnet information.
 
 **Usage Examples:**
 
-* `ipealc <ip_address> <subnet_mask>`: Calculates the network address, broadcast address, and available host range for the specified IP address and subnet mask.
-* `ipealc -c <cidr_notation>`: Calculates the subnet mask and other information based on the CIDR notation.
-* `ipealc -n <network_address> <prefix_length>`: Calculates the network information based on the network address and prefix length.
-* `ipealc -h`: Displays the help menu for the ipealc tool, including all available options and usage examples.
-* `ipealc -v`: Displays the version information for the ipealc tool.
+* `ipcalc <ip_address> <subnet_mask>`: Calculates the network address, broadcast address, and available host range for the specified IP address and subnet mask.
+* `ipcalc -c <cidr_notation>`: Calculates the subnet mask and other information based on the CIDR notation.
+* `ipcalc -n <network_address> <prefix_length>`: Calculates the network information based on the network address and prefix length.
+* `ipcalc -h`: Displays the help menu for the ipcalc tool, including all available options and usage examples.
+* `ipcalc -v`: Displays the version information for the ipcalc tool.
 
 
 ## nsenter

--- a/docs/resources/linux/linux-static-performace-tools.md
+++ b/docs/resources/linux/linux-static-performace-tools.md
@@ -50,7 +50,7 @@ lscpu            # CPU architecture information
 cpu-x            # CPU identification tool
 
 # CPU Performance Monitoring
-numact1          # NUMA topology and statistics
+numactl          # NUMA topology and statistics
 lstopo           # Hardware topology viewer
 dmidecode        # DMI table decoder
 ```
@@ -64,7 +64,7 @@ dmidecode        # Memory hardware information
 
 # Memory Performance Tools
 lstopo           # Memory topology visualization
-numact1          # NUMA memory statistics
+numactl          # NUMA memory statistics
 ```
 
 ### Operating System Level Tools
@@ -250,7 +250,7 @@ schedtool -a 0-3 1234
 schedtool -h
 ```
 
-#### numact1
+#### numactl
 ```bash
 # Show NUMA topology
 numactl --hardware

--- a/docs/resources/linux/unix-file-system-hierarachy.md
+++ b/docs/resources/linux/unix-file-system-hierarachy.md
@@ -16,7 +16,7 @@ The `/etc` directory is the home for system configuration files, including `cron
 
 ## Essential System Binaries (`/sbin`)
 
-The `/sbin` directory contains essential system binaries, which are executable files for system administration commands, such as `fdisk` (partition management), `fsck` (file system check and repair), `getty` (login process), `halt` (system shutdown), `ifconfig` (network interface configuration), `init` (system initialization), `mkfs` (file system creation), `mkswaP` (swap space creation), `reboot` (system reboot), and `route` (network routing configuration).
+The `/sbin` directory contains essential system binaries, which are executable files for system administration commands, such as `fdisk` (partition management), `fsck` (file system check and repair), `getty` (login process), `halt` (system shutdown), `ifconfig` (network interface configuration), `init` (system initialization), `mkfs` (file system creation), `mkswap` (swap space creation), `reboot` (system reboot), and `route` (network routing configuration).
 
 ## Read-Only User Application Support Data & Binaries (`/usr`)
 

--- a/docs/resources/ml/underTheHoodOfNeuralNetwork.md
+++ b/docs/resources/ml/underTheHoodOfNeuralNetwork.md
@@ -79,7 +79,7 @@
 - [NNPACK](https://github.com/Maratyszcza/NNPACK)
 
 #### Research Papers
-- "Random Search for Hyper-Parameter Optimization" - [arXiv:1803.09820](https://arxiv.org/abs/1803.09820)
+- "Random Search for Hyper-Parameter Optimization" - [Random Search for Hyper-Parameter Optimization](https://jmlr.org/papers/v13/bergstra12a.html)
 - "A Disciplined Approach to Neural Network Hyper-Parameters" - [arXiv:1803.09820](https://arxiv.org/abs/1803.09820)
 - "An Analysis of Deep Neural Network Models for Practical Applications" - [arXiv:1605.07678](https://arxiv.org/abs/1605.07678)
 

--- a/docs/roadmap/dsa/dsa.md
+++ b/docs/roadmap/dsa/dsa.md
@@ -1,4 +1,4 @@
-# Table of Content
+# Table of Contents
 1. [Language-Agnostic DSA Roadmap](#language-agnostic-dsa-roadmap)
 2. [Language-Agnostic DSA Resources](#language-agnostic-dsa-resources)
 


### PR DESCRIPTION
## resources

### cybersecurity

`cybsec.md`

- Added the last m missing part of link for W3Schools.

### linux

`linux-networking-tools.md`

- The `ping` command does not send any HTTP request so just removed.
- Corrected the typo with `ipcalc`, not `ipealc`.

`linux-static-performace-tools.md`

- Corrected the typo with `numactl`, not `numact1`.

`unix-file-system-hierarachy.md`

- Changed `mkswaP` to `mkswap`.

### ml

`underTheHoodOfNeuralNetwork.md`

- The link for `Random Search for Hyper-Parameter Optimization` was same as `A Disciplined Approach to Neural Network Hyper-Parameters` and couldn't find alternative in the arxiv so changed to jmlr.


## roadmap

### dsa

`dsa.md`

- Changed `Table of Content` to `Table of Contents`
